### PR TITLE
Fixed ConnectionLost event blocks thread

### DIFF
--- a/Source/VncSharp/RemoteDesktop.cs
+++ b/Source/VncSharp/RemoteDesktop.cs
@@ -636,7 +636,8 @@ namespace VncSharp
 		/// <exception cref="System.InvalidOperationException">Thrown if the RemoteDesktop control is in the Connected state.</exception>
 		protected void OnConnectionLost()
 		{
-			if (ConnectionLost != null) {
+            // If Terminal is terminated when vnc tab remains, Parent is null and ConnectionLost event block thread
+			if (ConnectionLost != null && this.Parent != null) {
 				ConnectionLost(this, EventArgs.Empty);
 			}
 		}


### PR DESCRIPTION
# Issue Summary

When Vnc tab remains, application cannot close even if user click close button.
In this case, main window vanishes, blank window appears and it remains much.

# Issue reason

When Application close, VncSharp.RemoteDesktop.ConnectionLost fires.
However, Parent of VncSharp.RemoteDesktop is already null. So  rd_ConnectionLost methods subscribed to ConnectionLost is not invoked and block main thread.

# Env

* Windows 7 SP1 Ultimate Japanse
* RAM: 16GB
* CPU: Intel i7-2600

# Screen Shot

![vnc](https://user-images.githubusercontent.com/6241854/29494683-868283c4-85ea-11e7-8cf4-4d268b1c9e63.gif)
