### PR TITLE
Add disconnect to right click menu

### DIFF
--- a/Source/Terminals/Forms/Controls/FavoritesMenuLoader.cs
+++ b/Source/Terminals/Forms/Controls/FavoritesMenuLoader.cs
@@ -37,6 +37,7 @@ namespace Terminals
             private EventHandler groupToolStripMenuItemClick;
             private EventHandler groupAddToolStripMenuItemClick;
 
+            internal const String COMMAND_DISCONNECT = "Disconnect";
             internal const String COMMAND_EXIT = "Exit";
             internal const String QUICK_CONNECT = "QuickConnect";
             internal const String COMMAND_SPECIAL = "SpecialCommands";
@@ -456,6 +457,7 @@ namespace Terminals
 
             private void AddGeneralTrayContextMenu()
             {
+                CreateGeneralTrayContextMenuItem(COMMAND_DISCONNECT, Resources.disconnect);
                 restoreScreenMenuItem = this.CreateGeneralTrayContextMenuItem(COMMAND_RESTORESCREEN, Resources.arrow_in);
                 fullScreenMenuItem = this.CreateGeneralTrayContextMenuItem(COMMAND_FULLSCREEN, Resources.arrow_out);
 

--- a/Source/Terminals/Forms/MainForm.cs
+++ b/Source/Terminals/Forms/MainForm.cs
@@ -732,6 +732,9 @@ namespace Terminals
                         break;
                     case FavoritesMenuLoader.COMMAND_SPECIAL:
                         return;
+                    case FavoritesMenuLoader.COMMAND_DISCONNECT:
+                        this.tabControlRemover.Disconnect();
+                        return;
                     default:
                         this.OnFavoriteTrayToolsStripClick(e);
                         break;


### PR DESCRIPTION
For those of us who wants to run Terminals like this
![image](https://user-images.githubusercontent.com/207073/31589031-c0d7e406-b1fa-11e7-88a9-a766282eb9ce.png)
It's quite nice to have the ability in the right click menu.

TODO: Only show it when there are tabs open, and close the tab that was rightclicked (if possible) instead of the one that's currently selected.

This should be seen as an improvement on it's own though :)