### PR TITLE
Enable running from a network location

### DIFF
--- a/Source/Terminals/app.config
+++ b/Source/Terminals/app.config
@@ -13,6 +13,9 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
   </startup>
+  <runtime>
+    <loadFromRemoteSources enabled="true" />
+  </runtime>
   <userSettings>
     <Terminals.Properties.Settings>
       <setting name="Initializer" serializeAs="String">


### PR DESCRIPTION
This configuration setting allows library loading from network locations. If the terminals program is located on a mapped drive or a network, currently it will crash on load due to it not being permitted to access the assemblies in the Plugins folder. This fixes that so that the tool can be run from a network share, as our department does.